### PR TITLE
Serialize workflow runs and harden fetch sync

### DIFF
--- a/.github/workflows/export-cleanup.yaml
+++ b/.github/workflows/export-cleanup.yaml
@@ -6,6 +6,10 @@ on:
     types: [completed]
   workflow_dispatch:
 
+concurrency:
+  group: podcast-cicd-main
+  cancel-in-progress: false
+
 jobs:
   export-cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/fetch-new-episode.yaml
+++ b/.github/workflows/fetch-new-episode.yaml
@@ -6,6 +6,10 @@ on:
     - cron: '0 23 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: podcast-cicd-main
+  cancel-in-progress: false
+
 jobs:
   fetch-new-episode:
     runs-on: ubuntu-latest
@@ -21,6 +25,9 @@ jobs:
         with:
           r-version: 'release'
           use-public-rspm: true
+
+      - name: Sync with remote before changes
+        run: git pull --rebase --autostash origin main
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
@@ -45,6 +52,7 @@ jobs:
           # Only commit if there are changes
           if ! git diff --staged --quiet; then
             git commit -m "🤖 Auto-update: New R Weekly episode(s) $(date +'%Y-%m-%d')"
+            git pull --rebase --autostash origin main
             git push
             echo "✅ Changes pushed successfully"
           else

--- a/.github/workflows/snapshot-cleanup.yaml
+++ b/.github/workflows/snapshot-cleanup.yaml
@@ -6,6 +6,10 @@ on:
     types: [completed]
   workflow_dispatch:
 
+concurrency:
+  group: podcast-cicd-main
+  cancel-in-progress: false
+
 jobs:
   snapshot-cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
- add a shared `concurrency` group to Fetch New Episode, Export Cleanup, and Snapshot Cleanup
- reintroduce remote sync in fetch workflow before mutating files and again before push

## Why
- prevent push races between cleanup workflows triggered by the same fetch run
- keep fetch workflow aligned with latest `main` before committing automation output

## Notes
- this keeps the optimized dependency caching setup from the workflow optimization merge